### PR TITLE
chore(plugin-test): change version to working

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,6 @@ jobs:
       - macos-latest
     steps:
       - name: asdf_plugin_test
-        uses: asdf-vm/actions/plugin-test@v4
+        uses: asdf-vm/actions/plugin-test@v3
         with:
           command: sourcery --version


### PR DESCRIPTION
Should fix fetching latest release of a tool

Related to: https://github.com/asdf-vm/actions/issues/595