### PR TITLE
feat: support ubuntu-22.04 install

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,11 @@ jobs:
           - ubuntu-22.04
     runs-on: ${{ matrix.os }}
     steps:
+      - name: Install Swift (Ubuntu only)
+        if: runner.os == 'Linux'
+        uses: swift-actions/setup-swift@v2
+        with:
+          swift-version: "5.10"
       - name: asdf_plugin_test
         uses: asdf-vm/actions/plugin-test@v3
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,3 +20,5 @@ jobs:
         uses: asdf-vm/actions/plugin-test@v3
         with:
           command: sourcery --version
+        env:
+          GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,9 +8,13 @@ on:
 
 jobs:
   plugin_test:
-    name: asdf plugin test
-    runs-on:
-      - macos-latest
+    name: asdf plugin test (${{ matrix.os }})
+    strategy:
+      matrix:
+        os:
+          - macos-latest
+          - ubuntu-22.04
+    runs-on: ${{ matrix.os }}
     steps:
       - name: asdf_plugin_test
         uses: asdf-vm/actions/plugin-test@v3

--- a/bin/download
+++ b/bin/download
@@ -28,7 +28,7 @@ case "$platform" in
 		unzip "$release_file" -d "$ASDF_DOWNLOAD_PATH" || fail "Could not extract $release_file"
 		;;
 	ubuntu-22.04)
-		tar -xJf "$release_file" -C "$ASDF_DOWNLOAD_PATH" || fail "Could not extract $release_file"
+		tar -xf "$release_file" -C "$ASDF_DOWNLOAD_PATH" || fail "Could not extract $release_file"
 		;;
 esac
 

--- a/bin/download
+++ b/bin/download
@@ -13,23 +13,23 @@ mkdir -p "$ASDF_DOWNLOAD_PATH"
 platform="$(get_platform)"
 
 case "$platform" in
-	macos)
-		release_file="$ASDF_DOWNLOAD_PATH/$TOOL_NAME-$ASDF_INSTALL_VERSION.zip"
-		;;
-	ubuntu-22.04)
-		release_file="$ASDF_DOWNLOAD_PATH/$TOOL_NAME-$ASDF_INSTALL_VERSION.tar.xz"
-		;;
+macos)
+	release_file="$ASDF_DOWNLOAD_PATH/$TOOL_NAME-$ASDF_INSTALL_VERSION.zip"
+	;;
+ubuntu-22.04)
+	release_file="$ASDF_DOWNLOAD_PATH/$TOOL_NAME-$ASDF_INSTALL_VERSION.tar.xz"
+	;;
 esac
 
 download_release "$ASDF_INSTALL_VERSION" "$release_file"
 
 case "$platform" in
-	macos)
-		unzip "$release_file" -d "$ASDF_DOWNLOAD_PATH" || fail "Could not extract $release_file"
-		;;
-	ubuntu-22.04)
-		tar -xf "$release_file" -C "$ASDF_DOWNLOAD_PATH" || fail "Could not extract $release_file"
-		;;
+macos)
+	unzip "$release_file" -d "$ASDF_DOWNLOAD_PATH" || fail "Could not extract $release_file"
+	;;
+ubuntu-22.04)
+	tar -xf "$release_file" -C "$ASDF_DOWNLOAD_PATH" || fail "Could not extract $release_file"
+	;;
 esac
 
 rm "$release_file"

--- a/bin/download
+++ b/bin/download
@@ -10,10 +10,26 @@ source "${plugin_dir}/lib/utils.bash"
 
 mkdir -p "$ASDF_DOWNLOAD_PATH"
 
-release_file="$ASDF_DOWNLOAD_PATH/$TOOL_NAME-$ASDF_INSTALL_VERSION.zip"
+platform="$(get_platform)"
+
+case "$platform" in
+	macos)
+		release_file="$ASDF_DOWNLOAD_PATH/$TOOL_NAME-$ASDF_INSTALL_VERSION.zip"
+		;;
+	ubuntu-22.04)
+		release_file="$ASDF_DOWNLOAD_PATH/$TOOL_NAME-$ASDF_INSTALL_VERSION.tar.xz"
+		;;
+esac
 
 download_release "$ASDF_INSTALL_VERSION" "$release_file"
 
-unzip "$release_file" -d "$ASDF_DOWNLOAD_PATH" || fail "Could not extract $release_file"
+case "$platform" in
+	macos)
+		unzip "$release_file" -d "$ASDF_DOWNLOAD_PATH" || fail "Could not extract $release_file"
+		;;
+	ubuntu-22.04)
+		tar -xJf "$release_file" -C "$ASDF_DOWNLOAD_PATH" || fail "Could not extract $release_file"
+		;;
+esac
 
 rm "$release_file"

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -6,6 +6,34 @@ GH_REPO="https://github.com/krzysztofzablocki/Sourcery"
 TOOL_NAME="sourcery"
 TOOL_TEST="sourcery --version"
 
+# Detect platform and return download details
+# Returns: "macos" | "ubuntu-22.04" or fails
+get_platform() {
+	local kernel
+	kernel="$(uname -s)"
+
+	case "$kernel" in
+		Darwin)
+			echo "macos"
+			;;
+		Linux)
+			# Check if Ubuntu 22.04
+			if [ -f /etc/os-release ]; then
+				# shellcheck source=/dev/null
+				source /etc/os-release
+				if [ "$ID" = "ubuntu" ] && [ "$VERSION_ID" = "22.04" ]; then
+					echo "ubuntu-22.04"
+					return
+				fi
+			fi
+			fail "Unsupported Linux distribution. Only Ubuntu 22.04 is supported."
+			;;
+		*)
+			fail "Unsupported OS: $kernel"
+			;;
+	esac
+}
+
 fail() {
 	echo -e "asdf-$TOOL_NAME: $*"
 	exit 1
@@ -39,12 +67,41 @@ ignore_invalid_versions() {
 	cut -d ' ' -f 6-
 }
 
+# Fetch Ubuntu asset URL from GitHub API
+# Pattern: finds asset matching *ubuntu*22.04*{arch}*.tar.xz
+get_ubuntu_asset_url() {
+	local version="$1"
+	local api_url asset_url arch
+
+	arch="$(uname -m)"
+	api_url="https://api.github.com/repos/krzysztofzablocki/Sourcery/releases/tags/${version}"
+
+	asset_url=$(curl "${curl_opts[@]}" "$api_url" 2>/dev/null | \
+		grep -o "\"browser_download_url\": *\"[^\"]*ubuntu[^\"]*22\\.04[^\"]*${arch}[^\"]*\\.tar\\.xz\"" | \
+		head -1 | \
+		sed 's/"browser_download_url": *"\([^"]*\)"/\1/')
+
+	if [ -z "$asset_url" ]; then
+		fail "Could not find Ubuntu 22.04 $arch asset for version $version"
+	fi
+
+	echo "$asset_url"
+}
+
 download_release() {
-	local version filename url
+	local version filename url platform
 	version="$1"
 	filename="$2"
+	platform="$(get_platform)"
 
-	url="$GH_REPO/releases/download/${version}/sourcery-${version}.zip"
+	case "$platform" in
+		macos)
+			url="$GH_REPO/releases/download/${version}/sourcery-${version}.zip"
+			;;
+		ubuntu-22.04)
+			url="$(get_ubuntu_asset_url "$version")"
+			;;
+	esac
 
 	echo "* Downloading $TOOL_NAME release $version..."
 	curl "${curl_opts[@]}" -o "$filename" -C - "$url" || fail "Could not download $url"

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -112,7 +112,12 @@ download_release() {
 	esac
 
 	echo "* Downloading $TOOL_NAME release $version..."
-	curl "${curl_opts[@]}" -o "$filename" -C - "$url" || fail "Could not download $url"
+	echo "  URL: $url" >&2
+	curl -fsSL -o "$filename" "$url" || fail "Could not download $url"
+	
+	# Debug: show file size and first bytes
+	echo "  Downloaded file size: $(wc -c < "$filename") bytes" >&2
+	echo "  First bytes (hex): $(head -c 8 "$filename" | xxd -p)" >&2
 }
 
 install_version() {

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -76,23 +76,17 @@ get_ubuntu_asset_url() {
 	arch="$(uname -m)"
 	api_url="https://api.github.com/repos/krzysztofzablocki/Sourcery/releases/tags/${version}"
 
-	echo "Fetching release info for version $version (arch: $arch)..." >&2
-
-	# Fetch API response (without -f to see errors)
 	api_response=$(curl -sL "$api_url" 2>&1)
 
-	# Extract the asset URL
 	asset_url=$(echo "$api_response" | \
 		grep -o '"browser_download_url": *"[^"]*ubuntu[^"]*22\.04[^"]*'"${arch}"'[^"]*\.tar\.xz"' | \
 		head -1 | \
 		sed 's/"browser_download_url": *"\([^"]*\)"/\1/')
 
 	if [ -z "$asset_url" ]; then
-		echo "API response (first 500 chars): ${api_response:0:500}" >&2
 		fail "Could not find Ubuntu 22.04 $arch asset for version $version"
 	fi
 
-	echo "Found asset URL: $asset_url" >&2
 	echo "$asset_url"
 }
 
@@ -112,12 +106,7 @@ download_release() {
 	esac
 
 	echo "* Downloading $TOOL_NAME release $version..."
-	echo "  URL: $url" >&2
 	curl -fsSL -o "$filename" "$url" || fail "Could not download $url"
-	
-	# Debug: show file size and first bytes
-	echo "  Downloaded file size: $(wc -c < "$filename") bytes" >&2
-	echo "  First bytes (hex): $(head -c 8 "$filename" | xxd -p)" >&2
 }
 
 install_version() {

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -6,6 +6,11 @@ GH_REPO="https://github.com/krzysztofzablocki/Sourcery"
 TOOL_NAME="sourcery"
 TOOL_TEST="sourcery --version"
 
+fail() {
+	echo -e "asdf-$TOOL_NAME: $*"
+	exit 1
+}
+
 # Detect platform and return download details
 # Returns: "macos" | "ubuntu-22.04" or fails
 get_platform() {
@@ -32,11 +37,6 @@ get_platform() {
 			fail "Unsupported OS: $kernel"
 			;;
 	esac
-}
-
-fail() {
-	echo -e "asdf-$TOOL_NAME: $*"
-	exit 1
 }
 
 curl_opts=(-fsSL)
@@ -71,20 +71,28 @@ ignore_invalid_versions() {
 # Pattern: finds asset matching *ubuntu*22.04*{arch}*.tar.xz
 get_ubuntu_asset_url() {
 	local version="$1"
-	local api_url asset_url arch
+	local api_url asset_url arch api_response
 
 	arch="$(uname -m)"
 	api_url="https://api.github.com/repos/krzysztofzablocki/Sourcery/releases/tags/${version}"
 
-	asset_url=$(curl "${curl_opts[@]}" "$api_url" 2>/dev/null | \
-		grep -o "\"browser_download_url\": *\"[^\"]*ubuntu[^\"]*22\\.04[^\"]*${arch}[^\"]*\\.tar\\.xz\"" | \
+	echo "Fetching release info for version $version (arch: $arch)..." >&2
+
+	# Fetch API response (without -f to see errors)
+	api_response=$(curl -sL "$api_url" 2>&1)
+
+	# Extract the asset URL
+	asset_url=$(echo "$api_response" | \
+		grep -o '"browser_download_url": *"[^"]*ubuntu[^"]*22\.04[^"]*'"${arch}"'[^"]*\.tar\.xz"' | \
 		head -1 | \
 		sed 's/"browser_download_url": *"\([^"]*\)"/\1/')
 
 	if [ -z "$asset_url" ]; then
+		echo "API response (first 500 chars): ${api_response:0:500}" >&2
 		fail "Could not find Ubuntu 22.04 $arch asset for version $version"
 	fi
 
+	echo "Found asset URL: $asset_url" >&2
 	echo "$asset_url"
 }
 

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -131,7 +131,21 @@ install_version() {
 
 	(
 		mkdir -p "$install_path"
-		cp -r "${ASDF_DOWNLOAD_PATH}/bin/${TOOL_NAME}" "$install_path"
+		
+		# Handle different archive structures per platform
+		local platform
+		platform="$(get_platform)"
+		
+		case "$platform" in
+			macos)
+				# macOS archive has bin/sourcery
+				cp -r "${ASDF_DOWNLOAD_PATH}/bin/${TOOL_NAME}" "$install_path"
+				;;
+			ubuntu-22.04)
+				# Ubuntu archive has sourcery at root
+				cp -r "${ASDF_DOWNLOAD_PATH}/${TOOL_NAME}" "$install_path"
+				;;
+		esac
 
 		local tool_cmd
 		tool_cmd="$(echo "$TOOL_TEST" | cut -d' ' -f1)"

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -18,24 +18,24 @@ get_platform() {
 	kernel="$(uname -s)"
 
 	case "$kernel" in
-		Darwin)
-			echo "macos"
-			;;
-		Linux)
-			# Check if Ubuntu 22.04
-			if [ -f /etc/os-release ]; then
-				# shellcheck source=/dev/null
-				source /etc/os-release
-				if [ "$ID" = "ubuntu" ] && [ "$VERSION_ID" = "22.04" ]; then
-					echo "ubuntu-22.04"
-					return
-				fi
+	Darwin)
+		echo "macos"
+		;;
+	Linux)
+		# Check if Ubuntu 22.04
+		if [ -f /etc/os-release ]; then
+			# shellcheck source=/dev/null
+			source /etc/os-release
+			if [ "$ID" = "ubuntu" ] && [ "$VERSION_ID" = "22.04" ]; then
+				echo "ubuntu-22.04"
+				return
 			fi
-			fail "Unsupported Linux distribution. Only Ubuntu 22.04 is supported."
-			;;
-		*)
-			fail "Unsupported OS: $kernel"
-			;;
+		fi
+		fail "Unsupported Linux distribution. Only Ubuntu 22.04 is supported."
+		;;
+	*)
+		fail "Unsupported OS: $kernel"
+		;;
 	esac
 }
 
@@ -78,9 +78,9 @@ get_ubuntu_asset_url() {
 
 	api_response=$(curl -sL "$api_url" 2>&1)
 
-	asset_url=$(echo "$api_response" | \
-		grep -o '"browser_download_url": *"[^"]*ubuntu[^"]*22\.04[^"]*'"${arch}"'[^"]*\.tar\.xz"' | \
-		head -1 | \
+	asset_url=$(echo "$api_response" |
+		grep -o '"browser_download_url": *"[^"]*ubuntu[^"]*22\.04[^"]*'"${arch}"'[^"]*\.tar\.xz"' |
+		head -1 |
 		sed 's/"browser_download_url": *"\([^"]*\)"/\1/')
 
 	if [ -z "$asset_url" ]; then
@@ -97,12 +97,12 @@ download_release() {
 	platform="$(get_platform)"
 
 	case "$platform" in
-		macos)
-			url="$GH_REPO/releases/download/${version}/sourcery-${version}.zip"
-			;;
-		ubuntu-22.04)
-			url="$(get_ubuntu_asset_url "$version")"
-			;;
+	macos)
+		url="$GH_REPO/releases/download/${version}/sourcery-${version}.zip"
+		;;
+	ubuntu-22.04)
+		url="$(get_ubuntu_asset_url "$version")"
+		;;
 	esac
 
 	echo "* Downloading $TOOL_NAME release $version..."
@@ -120,20 +120,20 @@ install_version() {
 
 	(
 		mkdir -p "$install_path"
-		
+
 		# Handle different archive structures per platform
 		local platform
 		platform="$(get_platform)"
-		
+
 		case "$platform" in
-			macos)
-				# macOS archive has bin/sourcery
-				cp -r "${ASDF_DOWNLOAD_PATH}/bin/${TOOL_NAME}" "$install_path"
-				;;
-			ubuntu-22.04)
-				# Ubuntu archive has sourcery at root
-				cp -r "${ASDF_DOWNLOAD_PATH}/${TOOL_NAME}" "$install_path"
-				;;
+		macos)
+			# macOS archive has bin/sourcery
+			cp -r "${ASDF_DOWNLOAD_PATH}/bin/${TOOL_NAME}" "$install_path"
+			;;
+		ubuntu-22.04)
+			# Ubuntu archive has sourcery at root
+			cp -r "${ASDF_DOWNLOAD_PATH}/${TOOL_NAME}" "$install_path"
+			;;
 		esac
 
 		local tool_cmd


### PR DESCRIPTION
## Add Ubuntu 22.04 Support

### Summary

This PR adds support for installing Sourcery on Ubuntu 22.04 LTS systems.

### Changes

#### `lib/utils.bash`

- **Added `get_platform()`** - Detects the current platform by checking `uname -s` and parsing `/etc/os-release` on Linux
  - Returns `macos` for Darwin systems
  - Returns `ubuntu-22.04` for Ubuntu 22.04 systems
  - Fails with clear error on unsupported systems

- **Added `get_ubuntu_asset_url()`** - Dynamically fetches the Ubuntu release asset URL from the GitHub API
  - Detects processor architecture via `uname -m` (supports `x86_64`, `aarch64`)
  - Matches assets with pattern `*ubuntu*22.04*{arch}*.tar.xz`
  - Returns the `browser_download_url` from the release assets

- **Updated `download_release()`** - Uses platform-specific download URLs:
  - macOS: `sourcery-{version}.zip`
  - Ubuntu: dynamically resolved from GitHub API

#### `bin/download`

- Added platform detection to select correct archive extension (`.zip` vs `.tar.xz`)
- Added platform-specific extraction commands:
  - macOS: `unzip`
  - Ubuntu: `tar -xf`

#### `.github/workflows/build.yml`

- Extended CI to use matrix strategy, running plugin tests on both `macos-latest` and `ubuntu-22.04`

### Why Dynamic URL Resolution?

The Ubuntu asset naming varies across Sourcery releases (e.g., `ubuntu-22.04.4` in 2.2.5 vs `ubuntu-22.04.5` in 2.2.6). Instead of hardcoding the asset name, we query the GitHub API to find the correct download URL for each version.

### Limitations

- Only Ubuntu 22.04 is supported on Linux
- Other Linux distributions will fail with a clear error message

### Testing

- [x] shellcheck passes
- [x] CI passes on macOS
- [x] CI passes on Ubuntu 22.04
