### PR TITLE
docs: update README.md

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Build
+name: asdf
 
 on:
   push:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,4 +1,4 @@
-name: Lint
+name: lint
 
 on:
   push:

--- a/.github/workflows/test-mise.yml
+++ b/.github/workflows/test-mise.yml
@@ -1,4 +1,4 @@
-name: test mise
+name: mise
 
 on:
   pull_request:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 <div align="center">
 
-# asdf-sourcery [![Build](https://github.com/younke/asdf-sourcery/actions/workflows/build.yml/badge.svg)](https://github.com/younke/asdf-sourcery/actions/workflows/build.yml) [![Lint](https://github.com/younke/asdf-sourcery/actions/workflows/lint.yml/badge.svg)](https://github.com/younke/asdf-sourcery/actions/workflows/lint.yml)
+# asdf-sourcery 
+
+[![Build](https://github.com/younke/asdf-sourcery/actions/workflows/build.yml/badge.svg)](https://github.com/younke/asdf-sourcery/actions/workflows/build.yml) [![Lint](https://github.com/younke/asdf-sourcery/actions/workflows/lint.yml/badge.svg)](https://github.com/younke/asdf-sourcery/actions/workflows/lint.yml) [![Mise](https://github.com/younke/asdf-sourcery/actions/workflows/test-mise.yml/badge.svg)](https://github.com/younke/asdf-sourcery/actions/workflows/test-mise.yml)
 
 [sourcery](https://krzysztofzablocki.github.io/Sourcery/) plugin for the [asdf version manager](https://asdf-vm.com).
 


### PR DESCRIPTION
## Summary

- Rename CI workflow names for consistency (`Build` → `asdf`, `Lint` → `lint`, `test mise` → `mise`)
- Improve README badge formatting by placing them on a separate line
- Add Mise workflow badge to README
