### PR TITLE
ci(workflows): minor changes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,8 +3,10 @@ name: asdf
 on:
   push:
     branches:
-      - main
+      - master
   pull_request:
+  schedule:
+    - cron: 0 0 * * 5
 
 jobs:
   plugin_test:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,7 +3,7 @@ name: lint
 on:
   push:
     branches:
-      - main
+      - master
   pull_request:
 
 jobs:

--- a/.github/workflows/test-mise.yml
+++ b/.github/workflows/test-mise.yml
@@ -1,8 +1,10 @@
 name: mise
 
 on:
-  pull_request:
   push:
+    branches:
+      - master
+  pull_request:
   schedule:
     - cron: 0 0 * * 5
 

--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -41,8 +41,8 @@ get_platform() {
 
 curl_opts=(-fsSL)
 
-if [ -n "${GITHUB_API_TOKEN:-}" ]; then
-	curl_opts=("${curl_opts[@]}" -H "Authorization: token $GITHUB_API_TOKEN")
+if [ -n "${GITHUB_TOKEN:-}" ]; then
+	curl_opts=("${curl_opts[@]}" -H "Authorization: token $GITHUB_TOKEN")
 fi
 
 sort_versions() {


### PR DESCRIPTION
## Summary

- Update CI workflows to use `master` as the default branch instead of `main`
- Add weekly scheduled run (cron) to the build workflow
- Rename `GITHUB_API_TOKEN` to `GITHUB_TOKEN` in utils.bash for consistency with GitHub Actions conventions

## Changes

### CI Workflows
- **build.yml**: Changed trigger branch from `main` to `master`, added weekly scheduled cron job
- **lint.yml**: Changed trigger branch from `main` to `master`
- **test-mise.yml**: Added `master` branch trigger for push events, reordered triggers

### Scripts
- **lib/utils.bash**: Renamed environment variable from `GITHUB_API_TOKEN` to `GITHUB_TOKEN`

## Test Plan

- [ ] Verify workflows trigger correctly on push to master
- [ ] Verify workflows trigger correctly on pull requests
- [ ] Verify scheduled runs work as expected
